### PR TITLE
java17 下java.ext.dirs 替换为CLASSPATH方式的修复

### DIFF
--- a/charts/rocketmq/templates/broker/configmap.yaml
+++ b/charts/rocketmq/templates/broker/configmap.yaml
@@ -21,7 +21,7 @@ data:
     fi
 
     export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
-    export CLASSPATH=".:${ROCKETMQ_HOME}/lib:${ROCKETMQ_HOME}/conf:${CLASSPATH}"
+    export CLASSPATH=".:${ROCKETMQ_HOME}/lib/*:${ROCKETMQ_HOME}/conf"
     
     JAVA_OPT="${JAVA_OPT} -server"
     JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_BROKER}"

--- a/charts/rocketmq/templates/broker/configmap.yaml
+++ b/charts/rocketmq/templates/broker/configmap.yaml
@@ -21,11 +21,10 @@ data:
     fi
 
     export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
-    export CLASSPATH=".:${ROCKETMQ_HOME}/conf:${CLASSPATH}"
+    export CLASSPATH=".:${ROCKETMQ_HOME}/lib:${ROCKETMQ_HOME}/conf:${CLASSPATH}"
     
     JAVA_OPT="${JAVA_OPT} -server"
     JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_BROKER}"
-    JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${ROCKETMQ_HOME}/lib"
     JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_EXT}"
     JAVA_OPT="${JAVA_OPT} -cp ${CLASSPATH}"
 


### PR DESCRIPTION
修复java.ext.dirs 废弃改用CLASSPATH后，${ROCKETMQ_HOME}/lib 需要改为 ${ROCKETMQ_HOME}/lib/*  ，否则main class会找不到

修复完成后 java 17版 rocketmq可正常运行

[admin@k8snode01 rocketmq]$ kubectl get pod
NAME                                     READY   STATUS    RESTARTS   AGE
mq-rocketmq-broker-master-0              1/1     Running   0          10m
mq-rocketmq-broker-master-1              1/1     Running   0          10m
mq-rocketmq-broker-replica-id1-0         1/1     Running   0          10m
mq-rocketmq-broker-replica-id1-1         1/1     Running   0          10m
mq-rocketmq-dashboard-7c947cf885-zqllm   1/1     Running   0          10m
mq-rocketmq-nameserver-0                 1/1     Running   0          10m
mq-rocketmq-nameserver-1                 1/1     Running   0          9m57s

[admin@k8snode01 rocketmq]$ kubectl logs mq-rocketmq-broker-master-0
openjdk version "17.0.9" 2023-10-17
OpenJDK Runtime Environment Temurin-17.0.9+9 (build 17.0.9+9)
OpenJDK 64-Bit Server VM Temurin-17.0.9+9 (build 17.0.9+9, mixed mode, sharing)
/runbroker.sh: 37: [: ASYNC_MASTER: unexpected operator
/runbroker.sh: 39: [: ASYNC_MASTER: unexpected operator
0
[exec] cat /home/rocketmq/broker.conf
brokerClusterName = rocketmq-cluster-a
deleteWhen = 04
fileReservedTime = 48
flushDiskType = ASYNC_FLUSH
waitTimeMillsInSendQueue = 1000

# generated config
brokerName = broker-g0
brokerRole = ASYNC_MASTER
brokerId = 0

java  -server -Xms1g -Xmx1g -XX:+UseG1GC  -cp .:/home/rocketmq/rocketmq-4.9.7/conf:/home/rocketmq/rocketmq-4.9.7/lib/* org.apache.rocketmq.broker.BrokerStartup -c /home/rocketmq/broker.conf
The broker[broker-g0, 10.233.97.51:10911] boot success. serializeType=JSON and name server is mq-rocketmq-nameserver-0.mq-rocketmq-nameserver:9876;mq-rocketmq-nameserver-1.mq-rocketmq-nameserver:9876